### PR TITLE
Retrieve required flags from Libnest2D target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 find_package(PythonInterp 3.5 REQUIRED)  # Dependency of SIP.
 find_package(PythonLibs 3.5 REQUIRED)  # Dependency of SIP.
 find_package(SIP REQUIRED)  # To create Python bindings.
-find_package(libnest2d REQUIRED)  # The library we're creating bindings for.
-find_package(Clipper REQUIRED)  # Dependency of libnest2d.
-find_package(NLopt REQUIRED)  # Dependency of libnest2d.
-find_package(Boost REQUIRED)  # Dependency of libnest2d.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLIBNEST2D_GEOMETRIES_clipper -DLIBNEST2D_OPTIMIZERS_nlopt -DLIBNEST2D_THREADING_std")  # Tell libnest2d to use Clipper and NLopt, and standard threads.
+find_package(Libnest2D REQUIRED)  # The library we're creating bindings for.
 
 # Some build options.
 set(CMAKE_CXX_STANDARD 11)
@@ -45,5 +41,5 @@ set(SIP_EXTRA_FILES_DEPEND
 )
 
 set(SIP_EXTRA_OPTIONS -g)  # Always release the GIL before calling C++ methods.
-include_directories(src/ ${SIP_INCLUDE_DIRS} ${Python3_INCLUDE_DIRS} ${CLIPPER_INCLUDE_DIRS} ${NLopt_INCLUDE_DIRS} ${LIBNEST2D_INCLUDE_DIRS})
-add_sip_python_module(pynest2d src/Pynest2D.sip ${CLIPPER_LIBRARIES} ${NLopt_LIBRARIES})
+include_directories(src/ ${SIP_INCLUDE_DIRS})
+add_sip_python_module(pynest2d src/Pynest2D.sip Libnest2D::libnest2d_headeronly)


### PR DESCRIPTION
Instead of setting include paths and libs manually, just use the imported target.
All required properties are set Libnest2DTargets.cmake.

This also adds the otherwise missing libpthread to the link libraries.