### PR TITLE
CURA-8146: Fix getting PyCapsule error on import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,6 @@ set(SIP_EXTRA_FILES_DEPEND
     src/String.sip
 )
 
-set(SIP_EXTRA_OPTIONS -g)  # Always release the GIL before calling C++ methods.
+set(SIP_EXTRA_OPTIONS -g -n PyQt5.sip)  # Always release the GIL before calling C++ methods. -n PyQt5.sip is required to not get the PyCapsule error
 include_directories(src/ ${SIP_INCLUDE_DIRS} ${Python3_INCLUDE_DIRS} ${CLIPPER_INCLUDE_DIRS} ${NLopt_INCLUDE_DIRS} ${LIBNEST2D_INCLUDE_DIRS})
 add_sip_python_module(pynest2d src/Pynest2D.sip ${CLIPPER_LIBRARIES} ${NLopt_LIBRARIES})


### PR DESCRIPTION
This fix overcomes the notorious `ValueError: PyCapsule_GetPointer called with incorrect name` that
we get if we do not import Arcus, Savitar, and pynest2d in cura_app.py (and other places) even if it
is not used.

All credits go to Rex Dieter for figuring that this missing flag was the issue.
https://src.fedoraproject.org/rpms/libarcus/pull-request/1#request_diff

CURA-8146