### PR TITLE
Update dependencies and SIP build configuration

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,3 +1,3 @@
-version: "5.12.0-alpha.0"
+version: "5.11.0-alpha.0"
 requirements:
-  - "nest2d/5.12.0-alpha.0"
+  - "nest2d/5.11.0-alpha.0"

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,3 +1,3 @@
-version: "5.10.0"
+version: "5.12.0-alpha.0"
 requirements:
-  - "nest2d/5.10.0"
+  - "nest2d/5.12.0-alpha.0"

--- a/conanfile.py
+++ b/conanfile.py
@@ -124,9 +124,8 @@ class PyNest2DConan(ConanFile):
 
         # Generate the Source code from SIP
         tc = self.python_requires["sipbuildtool"].module.SipBuildTool(self)
-        # Use the full path to sip-build from the CPython Scripts directory
-        sip_build_path = os.path.join(self.dependencies["cpython"].cpp_info.bindirs[0], "Scripts", "sip-build.exe")
-        tc.configure(sip_install_executable=sip_build_path)
+        # Auto-detect sip-build from CPython dependency (cross-platform)
+        tc.configure(cpython_dependency=self.dependencies["cpython"])
         tc.build()
 
     def layout(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -70,8 +70,8 @@ class PyNest2DConan(ConanFile):
     def requirements(self):
         for req in self.conan_data["requirements"]:
             self.requires(req)
-        self.requires("cpython/3.12.2")
-        self.requires("nlopt/2.7.1")
+        self.requires("cpython/3.12.7")
+        self.requires("nlopt/2.10.0")
 
         # Although not a direct dependency, clipper is for some reason required at link-time
         self.requires("clipper/6.4.2@ultimaker/stable")
@@ -124,7 +124,9 @@ class PyNest2DConan(ConanFile):
 
         # Generate the Source code from SIP
         tc = self.python_requires["sipbuildtool"].module.SipBuildTool(self)
-        tc.configure()
+        # Use the full path to sip-build from the CPython Scripts directory
+        sip_build_path = os.path.join(self.dependencies["cpython"].cpp_info.bindirs[0], "Scripts", "sip-build.exe")
+        tc.configure(sip_install_executable=sip_build_path)
         tc.build()
 
     def layout(self):


### PR DESCRIPTION
This pull request updates dependency versions and improves the SIP build configuration in `conanfile.py`. The main changes are upgrading `cpython` and `nlopt` to newer versions, and ensuring the SIP build tool uses the correct executable path.

**Dependency upgrades:**

* Updated `cpython` requirement from version `3.12.2` to `3.12.7` to use the latest stable release.
* Updated `nlopt` requirement from version `2.7.1` to `2.10.0` for improved features and bug fixes.

**Build configuration improvements:**

* Modified the SIP build process to explicitly use the full path to `sip-build.exe` from the CPython Scripts directory, improving reliability of source code generation.

CURA-12814